### PR TITLE
Allow underscores in command names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,4 +60,4 @@ jobs:
           file: coverage.xml
           fail_ci_if_error: True
           verbose: True
-
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         CONDA_PY:
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"
@@ -54,7 +55,7 @@ jobs:
       - name: "CodeCov"
         if: ${{ github.repository == 'dwhswenson/plugcli'
                 && github.event != 'schedule' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: coverage.xml
           fail_ci_if_error: True

--- a/plugcli/cli.py
+++ b/plugcli/cli.py
@@ -44,8 +44,10 @@ class CLI(click.MultiCommand):
 
     def _register_plugin(self, plugin):
         self.plugins.append(plugin)
-        self._get_command[plugin.name] = plugin.command
-        self._sections[plugin.section].append(plugin.name)
+        # normalize underscores to hyphens
+        name = plugin.name.replace('_', '-')
+        self._get_command[name] = plugin.command
+        self._sections[plugin.section].append(name)
 
     def _deregister_plugin(self, plugin):
         # mainly used in testing


### PR DESCRIPTION
`plugcli` defaults to using `-` in command names, but allows users to use either `_` or `-`. Internally, this is done by changing user input from `_` to `-`. But that requires that command writers define their commands with `-` as well.

This PR will allow command writers to use either `_` or `-`. We still normalize on `-`, but now the internally-used name is changed on plugin registration.

Thanks to @RiesBen for catching this!