### PR TITLE
tests: `setup` -> `setup_method`

### DIFF
--- a/plugcli/tests/test_params.py
+++ b/plugcli/tests/test_params.py
@@ -5,7 +5,7 @@ from plugcli.params import *
 
 class ParameterTest:
     plugcli_class = None
-    def setup(self):
+    def setup_method(self):
         if self.plugcli_class is Option:
             self.name = "--foo"
         elif self.plugcli_class is Argument:
@@ -62,7 +62,7 @@ class TestArgument(ParameterTest):
 
 
 class TestMultiStrategyGetter:
-    def setup(self):
+    def setup_method(self):
         self.pass_strategy = lambda user_input, context: str(user_input)
         self.fail_strategy = lambda user_input, context: NOT_PARSED
         self.error_message = "bad input '{user_input}'"

--- a/plugcli/tests/test_plugin_management.py
+++ b/plugcli/tests/test_plugin_management.py
@@ -11,7 +11,7 @@ import click
 
 
 class PluginLoaderTest(object):
-    def setup(self):
+    def setup_method(self):
         self.expected_section = {'exampleA': "Simulation",
                                  'exampleB': "Miscellaneous"}
 
@@ -50,8 +50,8 @@ class PluginLoaderTest(object):
 
 class TestFilePluginLoader(PluginLoaderTest):
     LoaderClass = FilePluginLoader
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         # use our own commands dir as a file-based plugin
         parent = pathlib.Path(__file__).resolve().parent
         self.commands_dir = parent / "plugin_examples"
@@ -64,8 +64,8 @@ class TestFilePluginLoader(PluginLoaderTest):
 
 class TestNamespacePluginLoader(PluginLoaderTest):
     LoaderClass = NamespacePluginLoader
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self.namespace = "plugcli.tests.plugin_examples"
         self.loader = self.LoaderClass(self.namespace, CommandPlugin)
         self.plugin_type = 'namespace'


### PR DESCRIPTION
Pytest prefers (and now, apparently requires) the use of `setup_method` instead of `setup`.