### PR TITLE
Update miniconda action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          use-mamba: true
           python-version: ${{ matrix.CONDA_PY }}
-          miniforge-variant: Mambaforge
+          miniforge-variant: latest
       - name: "Install"
         run: |
           python -m pip install -e .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: ${{ matrix.CONDA_PY }}
-          miniforge-variant: latest
+          miniforge-version: latest
       - name: "Install"
         run: |
           python -m pip install -e .


### PR DESCRIPTION
Mambaforge has been deprecated, since all the functionality was moved into Miniforge.